### PR TITLE
Basic filter typing

### DIFF
--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -264,7 +264,7 @@ export class QueryBuilder<
       this.project,
       this.restricted,
       [...this.filters, filter]
-    );
+    )
   }
 
   get option() {

--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -249,7 +249,12 @@ export class QueryBuilder<
     >
   }
 
-  filter(filter: string) {
+  filter(filter: string): QueryBuilder<
+    Schema,
+    Mappings,
+    Type,
+    Project
+  > {
     return new QueryBuilder(
       this.schema,
       this.ordering,
@@ -259,16 +264,7 @@ export class QueryBuilder<
       this.project,
       this.restricted,
       [...this.filters, filter]
-    ) as unknown as Omit<
-      QueryBuilder<
-        Schema,
-        Mappings,
-        Type,
-        Project,
-        Exclude | 'filter'
-      >,
-      Exclude | 'filter'
-    >
+    );
   }
 
   get option() {

--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -259,7 +259,16 @@ export class QueryBuilder<
       this.project,
       this.restricted,
       [...this.filters, filter]
-    )
+    ) as unknown as Omit<
+      QueryBuilder<
+        Schema,
+        Mappings,
+        Type,
+        Project,
+        Exclude | 'filter'
+      >,
+      Exclude | 'filter'
+    >
   }
 
   get option() {

--- a/test/types/builder.spec.ts
+++ b/test/types/builder.spec.ts
@@ -45,7 +45,7 @@ describe('builder types', () => {
     const f = builder.pick(['_type', 'name']).first().use()[1]
     expectTypeOf(f).toEqualTypeOf<{ _type: 'author'; name: string }>()
 
-    const filterType = defineDocument('test', { title: { type: 'string' } }).builder.filter('').use()[1][0];
+    const filterType = defineDocument('test', { title: { type: 'string' } }).builder.filter('').use()[1][0]
     expectTypeOf(filterType).toEqualTypeOf<{ title: string; }>()
 
     // @ts-expect-error

--- a/test/types/builder.spec.ts
+++ b/test/types/builder.spec.ts
@@ -46,7 +46,7 @@ describe('builder types', () => {
     expectTypeOf(f).toEqualTypeOf<{ _type: 'author'; name: string }>()
 
     const filterType = defineDocument('test', { title: { type: 'string' } }).builder.filter('').use()[1][0];
-    expectTypeOf(filterType).toEqualTypeOf<{ title: string; }>();
+    expectTypeOf(filterType).toEqualTypeOf<{ title: string; }>()
 
     // @ts-expect-error
     expectTypeOf(builder.pick('nothere'))

--- a/test/types/builder.spec.ts
+++ b/test/types/builder.spec.ts
@@ -45,6 +45,9 @@ describe('builder types', () => {
     const f = builder.pick(['_type', 'name']).first().use()[1]
     expectTypeOf(f).toEqualTypeOf<{ _type: 'author'; name: string }>()
 
+    const filterType = defineDocument('test', { title: { type: 'string' } }).builder.filter('').use()[1][0];
+    expectTypeOf(filterType).toEqualTypeOf<{ title: string; }>();
+
     // @ts-expect-error
     expectTypeOf(builder.pick('nothere'))
 


### PR DESCRIPTION
This adds the same typings as the other functions. It used to return `Record<string, any>` which makes the filter function useless from a typing perspective