### PR TITLE
fix: Fixed builder spec type for subqueries

### DIFF
--- a/test/types/builder.spec.ts
+++ b/test/types/builder.spec.ts
@@ -225,7 +225,7 @@ describe('builder types', () => {
           title: { type: 'string' },
         }).builder.use(),
       })
-      .use()[1][0].children
+      .use()[1][0]?.children
     expectTypeOf(subqueryType).toEqualTypeOf<
       {
         _createdAt: string


### PR DESCRIPTION
I noticed this was wrong on my end..
-- is this what you meant with the regression? @danielroe 