### PR TITLE
fix(types): resolve arrays correctly with multi-property resolver

### DIFF
--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -11,7 +11,9 @@ type ResolveFieldType<T> = T extends Record<string, any>
   : ResolverAction<T>
 
 interface ResolverFunction<T, Arr = false> {
-  <P extends keyof T>(props: P[]): ResolverAction<Pick<T, P>>
+  <P extends keyof T>(props: P[]): Arr extends true
+    ? ResolveFieldType<Array<Pick<T, P>>>
+    : ResolverAction<Pick<T, P>>
 }
 interface ResolverFunction<T, Arr = false> {
   <P extends keyof T>(prop: P): Arr extends true

--- a/test/builder.spec.ts
+++ b/test/builder.spec.ts
@@ -1,6 +1,5 @@
 import groq from 'groq'
 import { describe, test, expect } from 'vitest'
-
 import { defineDocument, defineFields } from 'sanity-typed-queries'
 
 const { author } = defineDocument('author', {

--- a/test/types/builder.spec.ts
+++ b/test/types/builder.spec.ts
@@ -222,6 +222,18 @@ describe('builder types', () => {
         .first()
         .use()[1]
     ).toEqualTypeOf<string[][]>()
+    expectTypeOf(
+      referenceBuilder
+        .map(r => ({ fields: r.authors.resolveIn(['_id', 'more']).use() }))
+        .pick('fields')
+        .first()
+        .use()[1]
+    ).toEqualTypeOf<
+      {
+        _id: string
+        more: string[]
+      }[]
+    >()
 
     const subqueryType = defineDocument('test', { title: { type: 'string' } })
       .builder.subquery({


### PR DESCRIPTION
This sort of resolves #102 - the GROQ was already generated correctly, but the multi property resolver typing wasn't accounting for array types. Added a test and type logic for this to work:
```
const [query] = movie
  .map(h => ({ cast: h.castMembers.resolveIn(['name', 'otherfield']).use() }))
  .pick(['title', 'cast'])
  .use()
```