### PR TITLE
fix: sort keys in projection

### DIFF
--- a/src/query/builder.ts
+++ b/src/query/builder.ts
@@ -385,7 +385,9 @@ export class QueryBuilder<
 
     const innerProjection = [
       ...(this.restricted ? [] : ['...']),
-      ...entries.map(([key, val]) => (key === val ? key : `"${key}": ${val}`)),
+      ...entries
+        .sort((a, b) => a[0].localeCompare(b[0]))
+        .map(([key, val]) => (key === val ? key : `"${key}": ${val}`)),
     ].join(', ')
 
     return ` { ${innerProjection} }`


### PR DESCRIPTION
If the keys are unsorted, can cause bugs between server and client; especially when trying to cache a query.