### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sanity-typed-queries",
   "version": "0.9.5",
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@11.1.2",
   "description": "A collection of helper functions to improve the typing of Sanity resources.",
   "author": {
     "name": "Daniel Roe <daniel@roe.dev>",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+  esbuild: false
+  simple-git-hooks: true
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`